### PR TITLE
Fix a failing test with Python 3.9

### DIFF
--- a/test/test_package_identification_bazel.py
+++ b/test/test_package_identification_bazel.py
@@ -48,9 +48,9 @@ def test_identify():
         assert desc.type == 'bazel'
 
         desc.name = 'other-name'
-        with pytest.raises(RuntimeError) as e:
+        with pytest.raises(RuntimeError) as einfo:
             extension.identify(desc)
-        assert str(e).endswith('Package name already set to different value')
+        assert str(einfo.value).endswith('Package name already set to different value')
 
         (basepath / 'BUILD.bazel').write_text(
             'java_binary(\n'


### PR DESCRIPTION
`pytest.raises()` is returning an `ExceptionInfo` instance, not an `Execption` instance. In Python 3.9, it appears that the string representation of an `ExceptionInfo` instance is no longer the same as the string representation of the value it describes, making this test fail.

Specifically referencing the exception value property resolves the issue. I also changed the name of the variable to make it more clear that this is not an `Exception` instance.

```
>           assert str(e).endswith('Package name already set to different value')
E           assert False
E            +  where False = <built-in method endswith of str object at 0x7f6c2f7346f0>('Package name already set to different value')
E            +    where <built-in method endswith of str object at 0x7f6c2f7346f0> = "<ExceptionInfo RuntimeError('Package name already set to different value') tblen=2>".endswith
E            +      where "<ExceptionInfo RuntimeError('Package name already set to different value') tblen=2>" = str(<ExceptionInfo RuntimeError('Package name already set to different value') tblen=2>)

test/test_package_identification_bazel.py:53: AssertionError
```