### PR TITLE
Use raw strings for each part a regex

### DIFF
--- a/colcon_bazel/package_identification/bazel.py
+++ b/colcon_bazel/package_identification/bazel.py
@@ -135,17 +135,17 @@ def extract_project_name(content):
     # extract project name
     match = re.search(
         # keyword
-        'name'
+        r'name'
         # optional white space
-        '\s*'
+        r'\s*'
         # equal assignment
-        '\='
+        r'\='
         # optional white space
-        '\s*'
+        r'\s*'
         # optional "opening" quote
-        '("?)'
+        r'("?)'
         # project name
-        '([a-zA-Z0-9_-]+)'
+        r'([a-zA-Z0-9_-]+)'
         # optional "closing" quote (only if an "opening" quote was used)
         r'\1',
         content)


### PR DESCRIPTION
The backslashes in this regex are causing `DeprecationWarning`s to appear because they aren't valid escape sequences. Clearly they're meant as literal backslashes given the context, so using raw strings makes sense. I set the other parts of the regex as raw strings as well since escape characters are far less common in regular expressions than backslash characters, and it's easy to forget to make the string raw when modifying an existing one to contain a new backslash.

```
colcon_bazel/package_identification/bazel.py:140
  /colcon_bazel/package_identification/bazel.py:140: DeprecationWarning: invalid escape sequence \s
    '\s*'

colcon_bazel/package_identification/bazel.py:142
  /colcon_bazel/package_identification/bazel.py:142: DeprecationWarning: invalid escape sequence \=
    '\='

colcon_bazel/package_identification/bazel.py:144
  /colcon_bazel/package_identification/bazel.py:144: DeprecationWarning: invalid escape sequence \s
    '\s*'
```