### PR TITLE
Reduce priority of Bazel vs CMake

### DIFF
--- a/colcon_bazel/package_identification/bazel.py
+++ b/colcon_bazel/package_identification/bazel.py
@@ -26,6 +26,12 @@ from pyparsing import Word
 class BazelPackageIdentification(PackageIdentificationExtensionPoint):
     """Identify Bazel packages with `BUILD` files."""
 
+    # Set the priority slightly lower than the default.
+    # In the case that there are files for both Bazel and CMake, this will
+    # allow CMake to 'win'.
+    # This can be overridden via colcon metadata or colcon.pkg files.
+    PRIORITY = 90
+
     def __init__(self):  # noqa: D107
         super().__init__()
         satisfies_version(


### PR DESCRIPTION
Fixes https://github.com/ignitionrobotics/ign-bazel/issues/35

In projects with both `BUILD.bazel` and `CMakeLists.txt`, both `colcon` package plugin extensions have the same priority.   This causes multiple matches and then `colcon` will exclude it from the build.

For example:
```
[0.316s] WARNING:colcon.colcon_core.package_identification:No valid Build content
[0.318s] WARNING:colcon.colcon_core.package_identification:_identify(src/ign-math) has multiple matches and therefore is being ignored: bazel, cmake
```

This PR lowers the bazel priority so that CMake will "win" in these cases.  This can always be overridden via colcon's metadata colcon.pkg files.