### PR TITLE
Use extras_require[test] instead of tests_require

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,10 @@ install_requires =
   colcon-library-path
   pyparsing
 packages = find:
-tests_require =
+zip_safe = true
+
+[options.extras_require]
+test =
   flake8
   flake8-blind-except
   flake8-builtins
@@ -48,7 +51,6 @@ tests_require =
   pytest
   pytest-asyncio
   pytest-cov
-zip_safe = true
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
This will align the test requirement expression mechanism with the reset of the colcon packages.