### PR TITLE
Specifically ignore a non-test class which begins with 'Test'

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ exclude =
 
 [tool:pytest]
 junit_suite_name = colcon-bazel
+python_classes = !TestPackageArguments
 
 [options.entry_points]
 colcon_argcomplete.argcomplete_completer =


### PR DESCRIPTION
```
../../install/lib/python3.11/site-packages/colcon_core/verb/test.py:32
  install/lib/python3.11/site-packages/colcon_core/verb/test.py:32: PytestCollectionWarning: cannot collect test class 'TestPackageArguments' because it has a __init__ constructor (from: test/test_task_bazel_test.py)
    class TestPackageArguments:

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

Imported here: https://github.com/colcon/colcon-bazel/blob/d59e8c57a977c963e09a90619ee448d1adb008e2/test/test_task_bazel_test.py#L11