### PR TITLE
Fix ArgcompleteCompleterExtensionPoint optional import

### DIFF
--- a/colcon_bazel/argcomplete_completer/bazel_args.py
+++ b/colcon_bazel/argcomplete_completer/bazel_args.py
@@ -7,6 +7,7 @@ try:
         import ArgcompleteCompleterExtensionPoint
 except ImportError:
     class ArgcompleteCompleterExtensionPoint:  # noqa: D101
+        EXTENSION_POINT_VERSION = '1.0'
         pass
 from colcon_core.plugin_system import satisfies_version
 


### PR DESCRIPTION
```
  self = <colcon_bazel.argcomplete_completer.bazel_args.BazelArgcompleteCompleter object at 0x7f6a34e415e0>
  
      def __init__(self):  # noqa: D107
          super().__init__()
          satisfies_version(
  >           ArgcompleteCompleterExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
  E       AttributeError: type object 'ArgcompleteCompleterExtensionPoint' has no attribute 'EXTENSION_POINT_VERSION'
  
  colcon_bazel/argcomplete_completer/bazel_args.py:20: AttributeError
```