### PR TITLE
Fix some incorrect string literal comparisons

### DIFF
--- a/test/test_package_identification_bazel.py
+++ b/test/test_package_identification_bazel.py
@@ -30,13 +30,13 @@ def test_identify():
         (basepath / 'BUILD.bazel').write_text('')
         assert extension.identify(desc) is None
         assert desc.name is not None
-        assert desc.type is 'bazel'
+        assert desc.type == 'bazel'
 
         desc.name = None
         (basepath / 'BUILD').write_text('')
         assert extension.identify(desc) is None
         assert desc.name is not None
-        assert desc.type is 'bazel'
+        assert desc.type == 'bazel'
 
         desc.name = None
         (basepath / 'BUILD.bazel').write_text(


### PR DESCRIPTION
```
src/colcon-bazel/test/test_package_identification_bazel.py:33: SyntaxWarning: "is" with a literal. Did you mean "=="?
  assert desc.type is 'bazel'
src/colcon-bazel/test/test_package_identification_bazel.py:39: SyntaxWarning: "is" with a literal. Did you mean "=="?
  assert desc.type is 'bazel'
```