### PR TITLE
Add missing test dependency on colcon-argcomplete

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ zip_safe = true
 
 [options.extras_require]
 test =
+  colcon-argcomplete; sys_platform != 'win32'
   flake8
   flake8-blind-except
   flake8-builtins


### PR DESCRIPTION
These tests are expected to run on non-Win32 platforms: https://github.com/colcon/colcon-bazel/blob/master/test/test_argcomplete_completer_bazel_args.py