### PR TITLE
Fix master branch name in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: Run tests
 
 on:
   push:
-    branches: ['main']
+    branches: ['master']
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 colcon-bazel
 =============
 
-[![Travis CI](https://travis-ci.org/colcon/colcon-bazel.svg?branch=master)](https://travis-ci.org/colcon/colcon-bazel)
-[![AppVeyor](https://ci.appveyor.com/api/projects/status/github/colcon/colcon-bazel?svg=true&branch=master)](https://ci.appveyor.com/project/Theosakamg/colcon-bazel)
+[![GitHub Workflow](https://github.com/colcon/colcon-bazel/actions/workflows/ci.yaml/badge.svg?branch=master&event=push)](https://github.com/colcon/colcon-bazel/actions/workflows/ci.yaml?query=branch%3Amaster+event%3Apush)
 [![codecov](https://codecov.io/gh/colcon/colcon-bazel/branch/master/graph/badge.svg)](https://codecov.io/gh/colcon/colcon-bazel)
 [![PyPI version](https://img.shields.io/pypi/v/colcon_bazel.svg)](https://pypi.python.org/pypi/colcon_bazel/)
 


### PR DESCRIPTION
This was a copy/paste error with the previous change.

Fixes #23