### PR TITLE
Update deb platforms for release

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -2,5 +2,5 @@
 No-Python2:
 Depends: bazel
 Depends3: python3-colcon-core (>= 0.3.9), python3-colcon-library-path, python3-pyparsing
-Suite: focal jammy bullseye bookworm
+Suite: focal jammy noble bookworm trixie
 X-Python3-Version: >= 3.6


### PR DESCRIPTION
Added:
* Ubuntu Noble (24.04 LTS pre-release)
* Debian Trixie (testing)

Dropped:
* Debian Bullseye (oldstable)

Retained:
* Debian Bookworm (stable)
* Ubuntu Focal (20.04 LTS)
* Ubuntu Jammy (22.04 LTS)